### PR TITLE
Fix: Dragging to modify the order of service categories will fail whe…

### DIFF
--- a/module/catalogue/iml.go
+++ b/module/catalogue/iml.go
@@ -515,7 +515,10 @@ func (i *imlCatalogueModule) recurseUpdateSort(ctx context.Context, parent strin
 		if len(item.Children) < 1 {
 			continue
 		}
-		return i.recurseUpdateSort(ctx, item.Id, item.Children)
+		err = i.recurseUpdateSort(ctx, item.Id, item.Children)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Fix: Dragging to modify the order of service categories will fail when there are subcategories in the service category. #192 