### PR TITLE
chore: use official @module-federation/vite

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@ant-design/icons": "^5.2.6",
     "@ant-design/pro-components": "2.7.19",
-    "@originjs/vite-plugin-federation": "^1.3.3",
+    "@module-federation/vite": "^1.16.8",
     "@rollup/plugin-dynamic-import-vars": "^2.1.2",
     "@types/lodash-es": "^4.17.12",
     "@types/uuid": "^9.0.7",

--- a/frontend/packages/core/vite.config.ts
+++ b/frontend/packages/core/vite.config.ts
@@ -5,7 +5,7 @@ import path from 'path'
 import dynamicImportVars from '@rollup/plugin-dynamic-import-vars';
 import tailwindcss from 'tailwindcss';
 import autoprefixer from 'autoprefixer';
-import federation from "@originjs/vite-plugin-federation";
+import { federation } from '@module-federation/vite'
 
 export default defineConfig({
   cacheDir: './node_modules/.vite',
@@ -45,14 +45,18 @@ export default defineConfig({
         warnOnError:false
        }),
        federation({
-        name:"container",
-        remotes:{
-          remoteApp: 'http://localhost:5001/assets/remoteEntry.js' // 远程项目的URL
+        name: 'container',
+        remotes: {
+          remoteApp: {
+            type: 'module',
+            name: 'remoteApp',
+            entry: 'http://localhost:5001/assets/remoteEntry.js',
+            entryGlobalName: 'remoteApp',
+            shareScope: 'default'
+          }
         },
-        shared:[
-          "react",
-          "react-dom",
-        ]
+        filename: 'remoteEntry.js',
+        shared: ['react', 'react-dom']
       })
 
     ],


### PR DESCRIPTION
Hi :wave: 
@module-federation/vite is the official and supported Module Federation integration for Vite. [Read the announcement](https://www.linkedin.com/posts/voidzero_github-module-federationvite-vite-plugin-activity-7449452398202241024-JyAL).
It gives the maintained path for Vite-based federation, with upstream support for compatibility fixes, future Vite changes, and new Module Federation capabilities as they evolve.  